### PR TITLE
Add event listener to update line changes on file save

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,8 +40,14 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.window.showInformationMessage('Line changes updated!');
 	});
 
+	// Register an event listener to update line changes on file save
+	const saveEventListener = vscode.workspace.onDidSaveTextDocument(() => {
+		updateLineChanges();
+	});
+
 	context.subscriptions.push(disposable);
 	context.subscriptions.push(statusBarItem);
+	context.subscriptions.push(saveEventListener);
 }
 
 // This method is called when your extension is deactivated


### PR DESCRIPTION
Fixes #3

This pull request addresses the issue where line change counts were not updated upon file saves. A new event listener has been added to trigger the `updateLineChanges` function whenever a file is saved. The listener is registered and properly disposed of within the extension's lifecycle.