### PR TITLE
Make line count warning thresholds configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,15 +24,15 @@
       "type": "object",
       "title": "DiffLite Configuration",
       "properties": {
-        "difflite.gitWarningThresholds.small": {
+        "difflite.gitWarningThresholds.warning": {
           "type": "number",
           "default": 100,
-          "description": "The threshold for small warnings about line changes."
+          "description": "The threshold for warning-level line changes."
         },
-        "difflite.gitWarningThresholds.large": {
+        "difflite.gitWarningThresholds.critical": {
           "type": "number",
           "default": 150,
-          "description": "The threshold for large warnings about line changes."
+          "description": "The threshold for critical-level line changes."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
         "difflite.gitWarningThresholds.warning": {
           "type": "number",
           "default": 100,
-          "description": "The threshold for warning-level line changes."
+          "description": "The threshold to warn the user to start thinking about opening a PR."
         },
         "difflite.gitWarningThresholds.critical": {
           "type": "number",
           "default": 150,
-          "description": "The threshold for critical-level line changes."
+          "description": "The threshold to insist the user opens a PR."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,23 @@
         "command": "difflite.showLineChanges",
         "title": "Show Line Changes"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "DiffLite Configuration",
+      "properties": {
+        "difflite.gitWarningThresholds.small": {
+          "type": "number",
+          "default": 100,
+          "description": "The threshold for small warnings about line changes."
+        },
+        "difflite.gitWarningThresholds.large": {
+          "type": "number",
+          "default": 150,
+          "description": "The threshold for large warnings about line changes."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,10 +35,15 @@ export function activate(context: vscode.ExtensionContext) {
 
             const totalChanges = added + deleted;
 
+            // Fetch warning thresholds from settings
+            const config = vscode.workspace.getConfiguration('difflite');
+            const smallThreshold = config.get<number>('gitWarningThresholds.small', 100);
+            const largeThreshold = config.get<number>('gitWarningThresholds.large', 150);
+
             // Check for range transitions and show warnings accordingly
-            if (previousTotalChanges <= 100 && totalChanges > 100 && totalChanges <= 150) {
+            if (previousTotalChanges <= smallThreshold && totalChanges > smallThreshold && totalChanges <= largeThreshold) {
                 vscode.window.showWarningMessage('Commit is large; consider opening a PR.');
-            } else if (previousTotalChanges <= 150 && totalChanges > 150) {
+            } else if (previousTotalChanges <= largeThreshold && totalChanges > largeThreshold) {
                 vscode.window.showWarningMessage('Commit exceeds 150 lines; may be hard to review.');
             }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,13 +37,13 @@ export function activate(context: vscode.ExtensionContext) {
 
             // Fetch warning thresholds from settings
             const config = vscode.workspace.getConfiguration('difflite');
-            const smallThreshold = config.get<number>('gitWarningThresholds.small', 100);
-            const largeThreshold = config.get<number>('gitWarningThresholds.large', 150);
+            const warningThreshold = config.get<number>('gitWarningThresholds.warning', 100);
+            const criticalThreshold = config.get<number>('gitWarningThresholds.critical', 150);
 
             // Check for range transitions and show warnings accordingly
-            if (previousTotalChanges <= smallThreshold && totalChanges > smallThreshold && totalChanges <= largeThreshold) {
+            if (previousTotalChanges <= warningThreshold && totalChanges > warningThreshold && totalChanges <= criticalThreshold) {
                 vscode.window.showWarningMessage('Commit is large; consider opening a PR.');
-            } else if (previousTotalChanges <= largeThreshold && totalChanges > largeThreshold) {
+            } else if (previousTotalChanges <= criticalThreshold && totalChanges > criticalThreshold) {
                 vscode.window.showWarningMessage('Commit exceeds 150 lines; may be hard to review.');
             }
 


### PR DESCRIPTION
This pull request fixes #7 by introducing configurable thresholds for line count warnings in the settings page. The default values are set to 100 and 150 lines, respectively, and can now be adjusted by the user. Key changes include adding configuration properties in `package.json` and updating logic in `extension.ts` to fetch these values dynamically.