### PR TITLE
Add feature to track line counts against a specific branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,16 @@
           "type": "number",
           "default": 500,
           "description": "The threshold for deleted lines to insist the user opens a PR."
+        },
+        "difflite.compareWithBranch.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable tracking line counts against a specific branch."
+        },
+        "difflite.compareWithBranch.branch": {
+          "type": "string",
+          "default": "main",
+          "description": "The branch to compare the current branch against for line counts."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,15 +29,29 @@ export function activate(context: vscode.ExtensionContext) {
 			const unstaged = await git.diffSummary();
 			const staged = await git.diffSummary(['--cached']);
 
-			const added = unstaged.insertions + staged.insertions;
-			const deleted = unstaged.deletions + staged.deletions;
+			let added = unstaged.insertions + staged.insertions;
+			let deleted = unstaged.deletions + staged.deletions;
+
+            // Fetch settings
+            const config = vscode.workspace.getConfiguration('difflite');
+            const compareWithBranchEnabled = config.get<boolean>('compareWithBranch.enabled', false);
+            const compareWithBranch = config.get<string>('compareWithBranch.branch', 'main');
+
+            if (compareWithBranchEnabled) {
+                try {
+                    const branchDiff = await git.diffSummary([compareWithBranch]);
+                    added += branchDiff.insertions;
+                    deleted += branchDiff.deletions;
+                } catch (branchError) {
+                    console.error(`Error comparing with branch ${compareWithBranch}:`, branchError);
+                }
+            }
 
             statusBarItem.text = `$(diff-added) +${added} $(diff-removed) -${deleted}`;
             statusBarItem.tooltip = 'Git Changes';
             statusBarItem.show();
 
             // Fetch warning thresholds from settings
-            const config = vscode.workspace.getConfiguration('difflite');
             const additionsWarningThreshold = config.get<number>('gitWarningThresholds.additionsWarning', 100);
             const additionsCriticalThreshold = config.get<number>('gitWarningThresholds.additionsCritical', 150);
             const deletionsWarningThreshold = config.get<number>('gitWarningThresholds.deletionsWarning', 300);


### PR DESCRIPTION
This pull request fixes #15 by introducing a feature to track line counts against a designated branch, with `main` as the default. The changes include:

- Adding new settings to enable the feature and specify the branch for comparison.
- Updating the logic to include line counts from the specified branch using `git diff`.
- Handling errors gracefully when comparing with the branch fails.