### PR TITLE
Fix double counting of changed lines in plugin

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,8 +58,9 @@ export function activate(context: vscode.ExtensionContext) {
             if (compareWithBranchEnabled) {
                 try {
                     const branchDiff = await git.diffSummary([compareWithBranch]);
-                    added += branchDiff.insertions;
-                    deleted += branchDiff.deletions;
+                    // Adjust addition and deletion counts to prevent double counting
+                    added += Math.max(0, branchDiff.insertions - staged.insertions);
+                    deleted += Math.max(0, branchDiff.deletions - staged.deletions);
                 } catch (branchError) {
                     console.error(`Error comparing with branch ${compareWithBranch}:`, branchError);
                 }


### PR DESCRIPTION
This pull request fixes #20 by addressing the issue of double counting changed lines of code in the plugin. The changes adjust the addition and deletion counts by subtracting staged insertions and deletions from the branch differences, ensuring accurate line change tracking.